### PR TITLE
fix: env path

### DIFF
--- a/ytarchive.py
+++ b/ytarchive.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 import urllib.parse
 import urllib.request
 import urllib.error


### PR DESCRIPTION
Most of the Linux Release have its env placed in `/usr/bin/env` instead of `/bin/env`