### PR TITLE
Add ipv4/ipv6 selection support

### DIFF
--- a/ytarchive.py
+++ b/ytarchive.py
@@ -2,7 +2,7 @@
 import urllib.parse
 import urllib.request
 import urllib.error
-import http.client
+import socket
 import http.cookiejar
 import json
 import sys
@@ -1283,10 +1283,11 @@ def main():
 	add_meta = False
 	verbose = False
 	debug = False
+	inet_family = 0
 
 	try:
 		opts, args = getopt.getopt(sys.argv[1:],
-			"hwntvc:r:o:",
+			"hwntv46c:r:o:",
 			[
 				"help",
 				"wait",
@@ -1296,6 +1297,8 @@ def main():
 				"debug",
 				"vp9",
 				"add-metadata",
+				"ipv4",
+				"ipv6",
 				"cookies=",
 				"retry-stream=",
 				"output=",
@@ -1325,6 +1328,10 @@ def main():
 			debug = True
 		elif o == "--add-metadata":
 			add_meta = True
+		elif o in ("-4", "--ipv4"):
+			inet_family = socket.AF_INET
+		elif o in ("-6", "--ipv6"):
+			inet_family = socket.AF_INET6
 		elif o in ("-c", "--cookies"):
 			cfile = a
 		elif o in ("-o", "--output"):
@@ -1348,6 +1355,12 @@ def main():
 		loglevel = logging.INFO
 
 	logging.basicConfig(format="\r%(asctime)s %(levelname)s: %(message)s", datefmt="%H:%M:%S", level=loglevel)
+
+	# Set up inet_family
+	orig_getaddrinfo = socket.getaddrinfo
+	def new_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+		return orig_getaddrinfo(host=host, port=port, family=inet_family, type=type, proto=proto, flags=flags)
+	socket.getaddrinfo = new_getaddrinfo
 
 	if len(args) > 1:
 		info.url = args[0]


### PR DESCRIPTION
I didnt make a real test for this PR, but I've done a PoC:
```
import urllib.request
import socket
import re

orig_getaddrinfo = socket.getaddrinfo
inet_family = 0

def new_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
    return orig_getaddrinfo(host=host, port=port, family=inet_family, type=type, proto=proto, flags=flags)

socket.getaddrinfo = new_getaddrinfo

# Start PoC
r = urllib.request.urlopen('https://ip6.me')
print('Default: ' + re.search(r'\+3>(.*?)</', r.read().decode('utf-8')).group(1))

inet_family = socket.AF_INET
r = urllib.request.urlopen('https://ip6.me')
print('IPv4: ' + re.search(r'\+3>(.*?)</', r.read().decode('utf-8')).group(1))

inet_family = socket.AF_INET6
r = urllib.request.urlopen('https://ip6.me')
print('IPv6: ' + re.search(r'\+3>(.*?)</', r.read().decode('utf-8')).group(1))
```

Which gives me:
```
Default: <IPv6 Address>
IPv4: <IPv4 Address>
IPv6: <IPv6 Address>
```