### PR TITLE
logging tweaks

### DIFF
--- a/ytarchive.py
+++ b/ytarchive.py
@@ -190,29 +190,17 @@ class DownloadInfo:
 			print(self.status, end="")
 
 # Logging functions
-def get_clearing_space(msg):
-	term_cols = shutil.get_terminal_size().columns
-	space = term_cols - len(msg)
-	if space < 0:
-		space = 0
-
-	return space
-
 def logerror(msg):
-	space = get_clearing_space(msg)
-	logging.error("{0}{1}{2}".format(msg, " "*space, "\b"*space))
+	logging.error("{0}\033[K".format(msg))
 
 def logwarn(msg):
-	space = get_clearing_space(msg)
-	logging.warning("{0}{1}{2}".format(msg, " "*space, "\b"*space))
+	logging.warning("{0}\033[K".format(msg))
 
 def loginfo(msg):
-	space = get_clearing_space(msg)
-	logging.info("{0}{1}{2}".format(msg, " "*space, "\b"*space))
+	logging.info("{0}\033[K".format(msg))
 
 def logdebug(msg):
-	space = get_clearing_space(msg)
-	logging.debug("{0}{1}{2}".format(msg, " "*space, "\b"*space))
+	logging.debug("{0}\033[K".format(msg))
 
 # Remove any illegal filename chars
 # Not robust, but the combination of video title and id should prevent other illegal combinations
@@ -1441,6 +1429,7 @@ def print_help():
 	print("\tupload_date (string): Technically stream date, UTC timezone (YYYYMMDD)")
 
 def main():
+	os.system("")  # enable vt100 on win10 >= 1607
 	info = DownloadInfo()
 	opts = None
 	args = None

--- a/ytarchive.py
+++ b/ytarchive.py
@@ -189,18 +189,21 @@ class DownloadInfo:
 		with self.lock:
 			print(self.status, end="")
 
-# Logging functions
+# Logging functions;
+# ansi sgr 0=reset, 1=bold, while 3x sets the foreground color:
+#   0black 1red 2green 3yellow 4blue 5magenta 6cyan 7white
+
 def logerror(msg):
-	logging.error("{0}\033[K".format(msg))
+	logging.error("\033[31m{0}\033[0m\033[K".format(msg))
 
 def logwarn(msg):
-	logging.warning("{0}\033[K".format(msg))
+	logging.warning("\033[33m{0}\033[0m\033[K".format(msg))
 
 def loginfo(msg):
-	logging.info("{0}\033[K".format(msg))
+	logging.info("\033[32m{0}\033[0m\033[K".format(msg))
 
 def logdebug(msg):
-	logging.debug("{0}\033[K".format(msg))
+	logging.debug("\033[36m{0}\033[0m\033[K".format(msg))
 
 # Remove any illegal filename chars
 # Not robust, but the combination of video title and id should prevent other illegal combinations


### PR DESCRIPTION
use ansi escape sequences to clear the lines before printing log entries

should have higher performance and be more reliable than the previous approach of discarding screen contents by appending and erasing whitespace

also adds colors of course w

EDIT: this requires win10 from late 2016 or newer to work, otherwise there's a bit of garbage prefixed and suffixed to each log message