### PR TITLE
avoid filename collisions when merging

### DIFF
--- a/ytarchive.py
+++ b/ytarchive.py
@@ -1828,6 +1828,12 @@ def main():
 					"{0}={1}".format(k.upper(), v)
 				])
 	
+	mfile_name, mfile_ext = mfile.rsplit('.', 1)
+	mfile_ctr = 0
+	while os.path.exists(mfile):
+		mfile_ctr += 1
+		mfile = "{}-{}.{}".format(mfile_name, mfile_ctr, mfile_ext)
+
 	ffmpeg_args.append(mfile)
 
 	ffmpeg = shutil.which("ffmpeg")


### PR DESCRIPTION
ran into this while testing some other stuff -

if you rip and mux the same stream multiple times, you'll get stuck at `Muxing files` since FFmpeg is silently asking the yes/no question to overwrite the output file

this adds a serial number if the output file already exists