### PR TITLE
Fix unhandled exception while trying to update info.target_duration after stream processing was finished.

### DIFF
--- a/ytarchive.py
+++ b/ytarchive.py
@@ -917,7 +917,7 @@ def get_video_info(info):
             info.dash_manifest_url = streaming_data["dashManifestUrl"]
 
         formats = streaming_data["adaptiveFormats"]
-        info.target_duration = formats[0]["targetDurationSec"]
+        info.target_duration = formats[0].get("targetDurationSec", info.target_duration)
         dl_urls = get_download_urls(info, formats)
 
         if info.quality < 0:


### PR DESCRIPTION
Once started, download continues even after Youtube finished post-processing stream (I suppose until download link expire in 6 hours), but page data doesn't contain `targetDurationSec` property anymore, which leads to exception when script tries to update it.
```
DEBUG: Found script element with player response in watch page.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "ytarchive.py", line 1441, in download_stream
    get_video_info(info)
  File "ytarchive.py", line 893, in get_video_info
    info.target_duration = formats[0]["targetDurationSec"]
KeyError: 'targetDurationSec'

DEBUG: audio0: Starved for fragment numbers and stream is offline
DEBUG: audio0: exiting
```
After unhandled exception happens thread decides it's done and exits, and when all threads die script thinks download was finished and merges files as usual.