### PR TITLE
Clone http.DefaultTransport rather than making our own.

### DIFF
--- a/util.go
+++ b/util.go
@@ -85,14 +85,7 @@ var (
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	tr = &http.Transport{
-		DialContext:           DialContextOverride,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-	}
-	client = &http.Client{
-		Transport: tr,
-	}
+	client = DefaultClient()
 )
 
 var fnameReplacer = strings.NewReplacer(
@@ -164,6 +157,16 @@ func LogTrace(format string, args ...interface{}) {
 
 func DialContextOverride(ctx context.Context, network, addr string) (net.Conn, error) {
 	return networkOverrideDialer.DialContext(ctx, networkType, addr)
+}
+
+func DefaultClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DialContext = DialContextOverride
+	tr.ResponseHeaderTimeout = 10 * time.Second
+
+	return &http.Client{
+		Transport: tr,
+	}
 }
 
 // Remove any illegal filename chars


### PR DESCRIPTION
This lets us inherit the useful/sane defaults of the default transport.
The most obvious benefit it inherits is supporting HTTP(S)_PROXY env variables from the http.ProxyFromEnvironment function. This lets you set http(s)/socks5 proxies for the program to use. This could be manually set on the `Proxy` field of Transport, but there's really no reason not to just clone the default transport as a base.
`TLSHandshakeTimeout` is already set to 10 seconds on the default transport so I omitted setting that, `ResponseHeaderTimeout` isn't set by default though so I kept that around.