### PR TITLE
seek up to 5 days, not from 0

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -907,7 +907,6 @@ func (di *DownloadInfo) DownloadStream(dataType, dataFile string, progressChan c
 	seqChan := make(chan *seqChanInfo, di.Jobs*2)
 	closed := false
 	curFrag := 0
-	curSeq := 0
 	activeDownloads := 0
 	maxSeqs := -1
 	tries := 10
@@ -922,9 +921,13 @@ func (di *DownloadInfo) DownloadStream(dataType, dataFile string, progressChan c
 
 	if di.FragmentDur >= 0 && di.LastSq >= 0 {
 		curFrag = di.LastSq - LiveMaximumSeekable / di.FragmentDur
-		curSeq = curFrag
-		LogWarn("%s: YT only retains the livestream 5 days past for seeking, starting from sequence %d (latest is %d)", dataType, curFrag, di.LastSq)
 	}
+	if curFrag > 0 {
+		LogWarn("%s: YT only retains the livestream 5 days past for seeking, starting from sequence %d (latest is %d)", dataType, curFrag, di.LastSq)
+	} else {
+		curFrag = 0
+	}
+	curSeq := curFrag
 	startFrag := curFrag
 
 	if err != nil {


### PR DESCRIPTION
As YT only retains up to 5 days for seeking, it detects and adjusts sequence number to keep it working.

For any long enough livestreams, you'll get:
```
$ ./ytarchive -v https://www.youtube.com/watch?v=fEvM-OUbaKs best --threads 32
ytarchive 0.3.1
Selected quality: 720p (h264)
2022/05/05 03:44:06 INFO: Starting download to /home/lesmi/ytarchive-py/fEvM-OUbaKs__3833454310/Coffee Jazz Music - Chill Out Lounge Jazz Music Radio - 24_7 Live Stream - Slow Jazz-fEvM-OUbaKs.f140.ts
2022/05/05 03:44:06 INFO: Starting download to /home/lesmi/ytarchive-py/fEvM-OUbaKs__3833454310/Coffee Jazz Music - Chill Out Lounge Jazz Music Radio - 24_7 Live Stream - Slow Jazz-fEvM-OUbaKs.f136.ts
2022/05/05 03:44:06 WARNING: video: YT only retains the livestream 5 days past for seeking, starting from sequence 1125174 (latest is 1211574)
2022/05/05 03:44:06 WARNING: audio: YT only retains the livestream 5 days past for seeking, starting from sequence 1125174 (latest is 1211574)
Video Fragments: 363; Audio Fragments: 363; Max Sequence: 1211585; Total Downloaded: 56.17MiB
```