### PR TITLE
Fix colored output on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -852,6 +852,7 @@ func main() {
 	PrintVersion()
 	cliFlags.Parse(os.Args[1:])
 	colorable.EnableColorsStdout(nil)
+	log.SetOutput(colorable.NewColorableStderr())
 	retcode := 0
 
 	if showHelp {


### PR DESCRIPTION
Title, the default logger wasn't going through colorable so logging was broken because of the ANSI codes, shouldn't change anything for OSes other than Windows.