### PR TITLE
Add `--proxy` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Options:
 		See FORMAT OPTIONS below for a list of available format keys.
 		Default is '%(title)s-%(id)s'
 
+	--proxy <SCHEME>://[<USER>:<PASS>@]<HOST>:<PORT>
+		Specify a proxy to use for downloading. e.g.
+			- socks5://127.0.0.1:1080
+			- http://192.168.1.1:8080
+			- http://user:password@proxy.example.com:8080
+
+		HTTP, HTTPS and SOCKS5 proxy servers are supported.
+
 	-q
 	--quiet
 		Print nothing to the console except information relevant for user input.
@@ -264,6 +272,9 @@ Examples:
 	ytarchive -k -t --vp9 --monitor-channel --no-frag-files https://www.youtube.com/channel/UCvaTdHTWBGv3MKj3KVqJVCw/live best
 		Same as above, but waits for a stream on the given channel, and will
 		repeat the cycle after downloading each stream.
+
+	ytarchive --proxy http://127.0.0.1:9050 https://www.youtube.com/watch?v=2aIdHTuyYMA best
+		Downloads the given stream with a local HTTP proxy.
 
 FORMAT TEMPLATE OPTIONS
 	Format template keys provided are made to be the same as they would be for

--- a/main.go
+++ b/main.go
@@ -871,7 +871,7 @@ func run() int {
 	}
 
 	if err != nil {
-		LogError("%s not found. Please install ffmpeg or provide a location using --fmpeg-path", ffmpegPath)
+		LogError("%s not found. Please install ffmpeg or provide a location using --ffmpeg-path", ffmpegPath)
 		LogError("Attempting to write the command for muxing the file manually to %s", muxFile)
 
 		retcode = WriteMuxFile(muxFile, ffmpegCmd)

--- a/main.go
+++ b/main.go
@@ -160,6 +160,14 @@ Options:
 		See FORMAT OPTIONS below for a list of available format keys.
 		Default is '%[3]s'
 
+	--proxy <SCHEME>://[<USER>:<PASS>@]<HOST>:<PORT>
+		Specify a proxy to use for downloading. e.g.
+			- socks5://127.0.0.1:1080
+			- http://192.168.1.1:8080
+			- http://user:password@proxy.example.com:8080
+
+		HTTP, HTTPS and SOCKS5 proxy servers are supported.
+
 	-q
 	--quiet
 		Print nothing to the console except information relevant for user input.
@@ -283,6 +291,9 @@ Examples:
 	%[1]s -k -t --vp9 --monitor-channel --no-frag-files https://www.youtube.com/channel/UCvaTdHTWBGv3MKj3KVqJVCw/live best
 		Same as above, but waits for a stream on the given channel, and will
 		repeat the cycle after downloading each stream.
+
+	%[1]s --proxy http://127.0.0.1:9050 https://www.youtube.com/watch?v=2aIdHTuyYMA best
+		Downloads the given stream with a local HTTP proxy.
 
 FORMAT TEMPLATE OPTIONS
 	Format template keys provided are made to be the same as they would be for

--- a/util.go
+++ b/util.go
@@ -97,7 +97,7 @@ var (
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	client = DefaultClient()
+	client *http.Client
 )
 
 var fnameReplacer = strings.NewReplacer(
@@ -181,12 +181,17 @@ func DialContextOverride(ctx context.Context, network, addr string) (net.Conn, e
 	return networkOverrideDialer.DialContext(ctx, networkType, addr)
 }
 
-func DefaultClient() *http.Client {
+func InitializeHttpClient(proxyUrl *url.URL) {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
+
 	tr.DialContext = DialContextOverride
 	tr.ResponseHeaderTimeout = 10 * time.Second
+	if proxyUrl != nil {
+		// Override ProxyFromEnvironment (default setting)
+		tr.Proxy = http.ProxyURL(proxyUrl)
+	}
 
-	return &http.Client{
+	client = &http.Client{
 		Transport: tr,
 	}
 }


### PR DESCRIPTION
## First of all

`ytarchive` is a wonderful application that has helped me download a bunch of important livestreams. Thanks for your work!

## Motivation

I'm from China. Due to [the Great Firewall](https://en.wikipedia.org/wiki/Great_Firewall), the YouTube users from mainland China have to use proxies to watch or download videos. Currently, when using this application, to make it connect to YouTube, a VPN software or an proxy environment variable like `HTTPS_PROXY` is required. I think a built-in command line option would make things easier.

This pull request may resolve #35.

## Changes

I generally:

- Changed `main.go` to read the `--proxy` option and pass it into `*http.Client`. Since this requires exposing an initialize function for the `client` variable in `util.go`, I changed the `DefaultClient()` function in `util.go` to `InitializeHttpClient(proxyUrl *url.URL)` and call it in `main.go`.
- Added the syntax and example in the README.md file and the help message.
- Fixed a typo by the way.

## Test

I tested it myself and invited some friends to test it. The result on my computer is:

![Test Result (Snapshot)](https://user-images.githubusercontent.com/5251264/213676990-264bb61e-80d2-409b-a0c2-cc62df8b613c.png)

We can see that without the `--proxy` option, the application can't connect to YouTube. After specifying a proxy, it connects to the YouTube API and downloads video smoothly.

No bug was reported by my friends.