### PR TITLE
Increase required Go version to 1.17 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,14 @@
 module github.com/Kethsar/ytarchive
 
-go 1.16
+go 1.17
 
 require (
 	github.com/alessio/shellescape v1.4.1
 	github.com/mattn/go-colorable v0.1.11
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
+)
+
+require (
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 )


### PR DESCRIPTION
Otherwise, building it with recent Go throws an error:

    unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)