### PR TITLE
support URLs of the form 'www.youtube.com/live/<ID>'

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -482,6 +482,14 @@ func (di *DownloadInfo) ParseInputUrl() error {
 			di.URL = fmt.Sprintf("%s/live", di.URL)
 			di.LiveURL = true
 			return nil
+		} else if strings.HasPrefix(lowerPath, "/live/") {
+			videoID := strings.TrimPrefix(lowerPath, "/live/")
+			videoID = strings.Trim(videoID, "/")
+
+			if len(videoID) > 0 {
+				di.VideoID = videoID
+				return nil
+			}
 		}
 	} else if lowerHost == "youtu.be" {
 		di.VideoID = strings.TrimLeft(parsedUrl.EscapedPath(), "/")


### PR DESCRIPTION
The share button on the app/website now likes to give URLs of the form `https://www.youtube.com/live/<ID>?feature=share`, which currently ytarchive doesn't support and returns an error. This PR just adds support for that format.