### PR TITLE
Bump version to 0.4.0 in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ const (
 
 const (
 	MajorVersion = 0
-	MinorVersion = 3
-	PatchVersion = 2
+	MinorVersion = 4
+	PatchVersion = 0
 )
 
 var (


### PR DESCRIPTION
Recent tag seems to have bumped version without bumping it in the source.