### PR TITLE
fix typo

### DIFF
--- a/util.go
+++ b/util.go
@@ -628,7 +628,7 @@ func ContinueFragmentDownload(di *DownloadInfo, state *fragThreadState) bool {
 		if !di.IsLive() || di.IsUnavailable() {
 			if state.Is403 {
 				if di.IsUnavailable() {
-					LogWarn("%s: Download link likely expired and stream is privated or members only, cannot coninue download", state.Name)
+					LogWarn("%s: Download link likely expired and stream is privated or members only, cannot continue download", state.Name)
 				} else {
 					LogWarn("%s: Download link has likely expired and the stream has probably finished processing.", state.Name)
 					LogWarn("%s: You might want to use youtube-dl to download instead.", state.Name)


### PR DESCRIPTION
Fix typo, "coninue" -> "continue"