### PR TITLE
Fix MP4 fragment writing to work with ffmpeg 6.1

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -317,8 +317,8 @@ func (di *DownloadInfo) SetDownloadUrl(dataType, dlURL string) {
 }
 
 func (di *DownloadInfo) GetMimeType(dataType string) string {
-	di.MDLInfo[dataType].Lock()
-	defer di.MDLInfo[dataType].Unlock()
+	di.MDLInfo[dataType].RLock()
+	defer di.MDLInfo[dataType].RUnlock()
 
 	return di.MDLInfo[dataType].MimeType
 }

--- a/Info.go
+++ b/Info.go
@@ -837,7 +837,6 @@ func (di *DownloadInfo) downloadFragment(state *fragThreadState, dataChan chan<-
 	state.FullRetries = 3
 	state.Is403 = false
 	fname := fmt.Sprintf("%s.frag%d.ts", state.BaseFilePath, state.SeqNum)
-	mimeType := di.GetMimeType(state.DataType)
 
 	for state.Tries < int(di.FragMaxTries) || di.FragMaxTries == 0 {
 		if di.IsStopping() {
@@ -933,6 +932,11 @@ func (di *DownloadInfo) downloadFragment(state *fragThreadState, dataChan chan<-
 
 		if len(headerSeqnumStr) > 0 {
 			headerSeqnum, _ = strconv.Atoi(headerSeqnumStr)
+		}
+
+		mimeType := resp.Header.Get("Content-Type")
+		if !strings.HasSuffix(mimeType, "/mp4") && !strings.HasSuffix(mimeType, "/webm") {
+			LogTrace("%s: fragment %d has unknown MIME type '%s'", state.Name, state.SeqNum, mimeType)
 		}
 
 		if state.ToFile {

--- a/main.go
+++ b/main.go
@@ -341,8 +341,8 @@ var (
 	info              *DownloadInfo
 	cookieFile        string
 	fnameFormat       string
-	gvAudioUrl        string
-	gvVideoUrl        string
+	gvAudioUrl        StreamInfo
+	gvVideoUrl        StreamInfo
 	ffmpegPath        string
 	proxyUrl          *url.URL
 	threadCount       uint
@@ -563,17 +563,17 @@ func run() int {
 		}
 	}
 
-	if len(gvVideoUrl) > 0 {
-		info.URL = gvVideoUrl
-		info.SetDownloadUrl(DtypeVideo, gvVideoUrl)
+	if len(gvVideoUrl.URL) > 0 {
+		info.URL = gvVideoUrl.URL
+		info.SetStreamInfo(DtypeVideo, gvVideoUrl)
 	}
 
-	if len(gvAudioUrl) > 0 {
+	if len(gvAudioUrl.URL) > 0 {
 		if len(info.URL) == 0 {
-			info.URL = gvAudioUrl
+			info.URL = gvAudioUrl.URL
 		}
 
-		info.SetDownloadUrl(DtypeAudio, gvAudioUrl)
+		info.SetStreamInfo(DtypeAudio, gvAudioUrl)
 	}
 
 	if len(info.URL) == 0 {

--- a/main.go
+++ b/main.go
@@ -341,8 +341,8 @@ var (
 	info              *DownloadInfo
 	cookieFile        string
 	fnameFormat       string
-	gvAudioUrl        StreamInfo
-	gvVideoUrl        StreamInfo
+	gvAudioUrl        string
+	gvVideoUrl        string
 	ffmpegPath        string
 	proxyUrl          *url.URL
 	threadCount       uint
@@ -563,17 +563,17 @@ func run() int {
 		}
 	}
 
-	if len(gvVideoUrl.URL) > 0 {
-		info.URL = gvVideoUrl.URL
-		info.SetStreamInfo(DtypeVideo, gvVideoUrl)
+	if len(gvVideoUrl) > 0 {
+		info.URL = gvVideoUrl
+		info.SetDownloadUrl(DtypeVideo, gvVideoUrl)
 	}
 
-	if len(gvAudioUrl.URL) > 0 {
+	if len(gvAudioUrl) > 0 {
 		if len(info.URL) == 0 {
-			info.URL = gvAudioUrl.URL
+			info.URL = gvAudioUrl
 		}
 
-		info.SetStreamInfo(DtypeAudio, gvAudioUrl)
+		info.SetDownloadUrl(DtypeAudio, gvAudioUrl)
 	}
 
 	if len(info.URL) == 0 {

--- a/util.go
+++ b/util.go
@@ -27,12 +27,7 @@ import (
 )
 
 type MPD struct {
-	AdaptationSets []AdaptationSet `xml:"Period>AdaptationSet"`
-}
-
-type AdaptationSet struct {
-	MimeType        string           `xml:"mimeType,attr"`
-	Representations []Representation `xml:"Representation"`
+	Representations []Representation `xml:"Period>AdaptationSet>Representation"`
 }
 
 // DASH Manifest element containing Youtube's media ID and a download URL
@@ -446,8 +441,8 @@ func IsFragmented(url string) bool {
 }
 
 // Prase the DASH manifest XML and get the download URLs from it
-func GetUrlsFromManifest(manifest []byte) (map[int]StreamInfo, int) {
-	urls := make(map[int]StreamInfo)
+func GetUrlsFromManifest(manifest []byte) (map[int]string, int) {
+	urls := make(map[int]string)
 	var mpd MPD
 
 	err := xml.Unmarshal(manifest, &mpd)
@@ -458,34 +453,32 @@ func GetUrlsFromManifest(manifest []byte) (map[int]StreamInfo, int) {
 
 	lastSq := -1
 
-	for _, a := range mpd.AdaptationSets {
-		for _, r := range a.Representations {
-			itag, err := strconv.Atoi(r.Id)
-			if err != nil {
-				continue
-			}
+	for _, r := range mpd.Representations {
+		itag, err := strconv.Atoi(r.Id)
+		if err != nil {
+			continue
+		}
 
-			sl := r.SegmentList
-			if len(sl) > 0 {
-				lastMedia := sl[len(sl)-1].Media
-				paths := strings.Split(lastMedia, "/")
-				for i, ps := range paths {
-					if ps == "sq" && len(paths) >= i+1 {
-						lastSqC, err := strconv.Atoi(paths[i+1])
-						if err != nil {
-							lastSqC = -1
-						}
-						if lastSq < lastSqC {
-							lastSq = lastSqC
-						}
-						break
+		sl := r.SegmentList
+		if len(sl) > 0 {
+			lastMedia := sl[len(sl)-1].Media
+			paths := strings.Split(lastMedia, "/")
+			for i, ps := range paths {
+				if ps == "sq" && len(paths) >= i+1 {
+					lastSqC, err := strconv.Atoi(paths[i+1])
+					if err != nil {
+						lastSqC = -1
 					}
+					if lastSq < lastSqC {
+						lastSq = lastSqC
+					}
+					break
 				}
 			}
+		}
 
-			if itag > 0 && len(r.BaseURL) > 0 {
-				urls[itag] = StreamInfo{strings.ReplaceAll(r.BaseURL, "%", "%%") + "sq/%d", a.MimeType}
-			}
+		if itag > 0 && len(r.BaseURL) > 0 {
+			urls[itag] = strings.ReplaceAll(r.BaseURL, "%", "%%") + "sq/%d"
 		}
 	}
 
@@ -566,8 +559,8 @@ func GetVideoIdFromWatchPage(data []byte) string {
 	return string(data[startIdx:endIdx])
 }
 
-func ParseGvideoUrl(gvUrl, dataType string) (StreamInfo, int) {
-	var newUrl StreamInfo
+func ParseGvideoUrl(gvUrl, dataType string) (string, int) {
+	var newUrl string
 	parsedUrl, err := url.Parse(gvUrl)
 	if err != nil {
 		LogError("Error parsing Google Video URL: %s", err)
@@ -601,8 +594,7 @@ func ParseGvideoUrl(gvUrl, dataType string) (StreamInfo, int) {
 		sqIndex = len(gvUrl)
 	}
 
-	newUrl.URL = gvUrl[:sqIndex] + "&sq=%d"
-	newUrl.MimeType = parsedUrl.Query().Get("mime")
+	newUrl = gvUrl[:sqIndex] + "&sq=%d"
 	return newUrl, itag
 }
 


### PR DESCRIPTION
ffmpeg 6.1 fails to parse concatenated MP4 files with multiple ftyp atoms, so we have to remove all but the first.
Adds logic to pass the media mimetype through to the fragment downloader, previously the fragment downloader was trying to remove atoms from all fragments, including WEBM ones. This is pretty unlikely at actually cause issues unless by some freak chance the WEBM fragment has a valid MP4 atom in it, but figured I'd correct it anyways. Still falls back to removing from all fragments if the mimetype is blank for whatever reason.

I tested the mimetype detection with DASH and adaptive formats, both work fine, but I can't get raw Google video URLs to work (even on git master). Not sure if it's broken or I'm doing it wrong.