### PR TITLE
Add back homebrew install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Download the latest pre-release from [the releases page](https://github.com/Keth
 
 Alternatively, if you have Go properly installed and set up, run `go install github.com/Kethsar/ytarchive@dev`
 
+If you use Homebrew, you can install it with `brew install holoarchivists/tap/ytarchive`
+
 ## Usage
 
 ```


### PR DESCRIPTION
The formula for `ytarchive` was migrated to the HoloArchivists organisation tap, this should make things more consistent, as well as allow others to maintain the formula when I am not available:

https://github.com/HoloArchivists/homebrew-tap/blob/main/Formula/ytarchive.rb
