### PR TITLE
Log stream start time when the stream starts.

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -791,6 +791,7 @@ func (di *DownloadInfo) GetVideoInfo() bool {
 	}
 
 	if !di.InProgress {
+		LogGeneral("Stream started at time %s", pmfr.LiveBroadcastDetails.StartTimestamp)
 		di.FormatInfo.SetInfo(pr)
 		di.Metadata.SetInfo(di.FormatInfo)
 		if len(pmfr.Thumbnail.Thumbnails) > 0 {


### PR DESCRIPTION
The final, real start time isn't known until the stream actually starts. Knowing the real start time is useful for softchat.