### PR TITLE
Configuration to run in a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# build the application in a separate container to keep the final image small
+FROM golang:1.22 AS builder
+
+COPY . /app
+WORKDIR /app
+RUN GO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ytarchive .
+
+# setup the resulting image using the same base as the golang image
+FROM debian:bookworm
+
+# ffmpeg (5.1.4) from stable does not work properly so we have to install v6 from unstable
+# we copy config files for apt to add unstable as a source and pin all packages to stable
+COPY ./etc /etc
+# we also need to install ca-certificates to avoid SSL errors
+RUN apt-get update \
+    && apt-get --no-install-recommends -y install ca-certificates \
+    && apt-get -t sid --no-install-recommends -y install ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy the application over from the builder container
+COPY --from=builder /app/ytarchive /usr/local/bin
+
+# switch to a non-root user
+RUN useradd -m ytarchive
+USER ytarchive
+
+VOLUME [ "/output" ]
+WORKDIR /output
+
+# we use bash to allow for environment variable expansion in docker-compose files
+# and to avoid issues with parantheses in the output format
+ENTRYPOINT [ "/bin/bash", "-c" ]
+CMD [ "ytarchive -h" ]

--- a/Info.go
+++ b/Info.go
@@ -185,6 +185,9 @@ type DownloadInfo struct {
 
 	MDLInfo map[string]*MediaDLInfo
 	DLState map[int]*DownloadState
+
+	FileMode os.FileMode
+	DirMode  os.FileMode
 }
 
 func NewDownloadInfo() *DownloadInfo {
@@ -420,7 +423,7 @@ func (di *DownloadInfo) SaveState(itag int) {
 		return
 	}
 
-	err = os.WriteFile(di.DLState[itag].File, data, 0644)
+	err = os.WriteFile(di.DLState[itag].File, data, di.FileMode)
 	if err != nil {
 		LogWarn("Error when saving state: %s", err)
 		return
@@ -913,7 +916,7 @@ func (di *DownloadInfo) downloadFragment(state *fragThreadState, dataChan chan<-
 		}
 
 		if state.ToFile {
-			err = os.WriteFile(fname, respData, 0644)
+			err = os.WriteFile(fname, respData, di.FileMode)
 			if err != nil {
 				LogDebug("%s: Failed to write fragment %d to file: %s", state.Name, state.SeqNum, err)
 				di.PrintStatus()

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ Download the latest pre-release from [the releases page](https://github.com/Keth
 
 Alternatively, if you have Go properly installed and set up, run `go install github.com/Kethsar/ytarchive@dev`
 
+To use it with docker, build an image with `docker build . -t localhost/ytarchive`.
+Afterwards you can start a container and pass in a command as explained in the next section:
+```
+docker run --name ytarchive -v ./output:/output localhost/ytarchive ytarchive [OPTIONS] [url] [quality]`
+```
+
+Or start the container in interactive mode:
+```
+docker run -it --rm -v ./output:/output localhost/ytarchive ytarchive
+```
+
+Or adjust the `docker-compose.yml` to your needs and run a stack with multiple containers:
+```
+docker compose up -d
+```
+
 ## Usage
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+x-defaults:
+  &defaults
+  image: localhost/ytarchive
+  # restart: unless-stopped
+  # user: "1000:1000"
+  volumes:
+    # make sure to create these directories before running the stack and own them by the user above
+    - ./ytarchive/downloads:/downloads
+    - ./ytarchive/output:/output
+
+x-nocookies:
+  &nocookies
+  <<: *defaults
+  command: ["ytarchive -t --vp9 --monitor-channel --newline --no-frag-files -w -dp 0777 -fp 0666 -td \"/downloads\" -o \"/output/%(channel)s/%(upload_date)s_%(title)s\" \"$$URL\" best" ]
+
+x-withcookies:
+  &withcookies
+  <<: *defaults
+  command: ["ytarchive -c /cookies.txt -t --vp9 --monitor-channel --newline --no-frag-files -w -dp 0777 -fp 0666 -td \"/downloads\" -o \"/output/%(channel)s/%(upload_date)s_%(title)s\" \"$$URL\" best" ]
+  volumes:
+    - ./ytarchive/cookies.txt:/cookies.txt:ro
+
+services:
+  somechannel:
+    <<: *nocookies
+    environment:
+      - URL=https://www.youtube.com/@somechannel/live
+  anotherchannel:
+    <<: *withcookies
+    environment:
+      - URL=https://www.youtube.com/@anotherchannel/live

--- a/etc/apt/preferences.d/pinned-packages
+++ b/etc/apt/preferences.d/pinned-packages
@@ -1,0 +1,7 @@
+Package: *
+Pin: release a=bookworm
+Pin-Priority: 500
+
+Package: *
+Pin: release a=unstable
+Pin-Priority: 100

--- a/etc/apt/sources.list.d/debian.sid.list
+++ b/etc/apt/sources.list.d/debian.sid.list
@@ -1,0 +1,3 @@
+#Debian Sid kernel sources
+deb http://deb.debian.org/debian unstable main contrib non-free
+deb-src http://deb.debian.org/debian unstable main contrib non-free

--- a/player_response.go
+++ b/player_response.go
@@ -352,7 +352,7 @@ func (di *DownloadInfo) GetPlayerResponse(videoHtml []byte) (*PlayerResponse, er
 	if len(prData) == 0 {
 		if debug && di.InProgress {
 			LogDebug("Could not find player response from video watch page. Writing html file to %s.html", di.VideoID)
-			os.WriteFile(fmt.Sprintf("%s.html", di.VideoID), videoHtml, 0644)
+			os.WriteFile(fmt.Sprintf("%s.html", di.VideoID), videoHtml, di.FileMode)
 		}
 		return nil, fmt.Errorf("unable to retrieve player response object from watch page")
 	}

--- a/util.go
+++ b/util.go
@@ -336,7 +336,7 @@ func DownloadData(url string) []byte {
 Download the given url to the given file name.
 Obviously meant to be used for thumbnail images.
 */
-func DownloadThumbnail(url, fname string) bool {
+func DownloadThumbnail(url, fname string, fileMode os.FileMode) bool {
 	resp, err := client.Get(url)
 	if err != nil {
 		LogWarn("Failed to download thumbnail: %v", err)
@@ -350,7 +350,7 @@ func DownloadThumbnail(url, fname string) bool {
 		return false
 	}
 
-	err = os.WriteFile(fname, data, 0644)
+	err = os.WriteFile(fname, data, fileMode)
 	if err != nil {
 		LogWarn("Failed to write thumbnail: %v", err)
 		os.Remove(fname)


### PR DESCRIPTION
This adds a Dockerfile to build the application and install ffmpeg so it can be run in a container. I have also updated the readme and added an example configuration for docker compose.

Inside the container the application is run as a non-priviledged user, so I have added some cli arguments to make it possible to work around any permission problems that may arise due to that:
`--file-permissions` (or `-fp`) and `--directory-permissions` (or `-dp`) to specify which mode is used to create files and directories.

In addition I also added another option `--temp-directory` (or `-td`) to specify a directory for temporary files which solves #175 for me.

Disclaimer: This is the first time I did anything with go, so please excuse if I made any obvious mistakes in the code. It compiles and runs fine though, so hopefully everything should be ok.
