### PR TITLE
New cli options to control file creation

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -185,6 +185,9 @@ type DownloadInfo struct {
 
 	MDLInfo map[string]*MediaDLInfo
 	DLState map[int]*DownloadState
+
+	FileMode os.FileMode
+	DirMode  os.FileMode
 }
 
 func NewDownloadInfo() *DownloadInfo {
@@ -420,7 +423,7 @@ func (di *DownloadInfo) SaveState(itag int) {
 		return
 	}
 
-	err = os.WriteFile(di.DLState[itag].File, data, 0644)
+	err = os.WriteFile(di.DLState[itag].File, data, di.FileMode)
 	if err != nil {
 		LogWarn("Error when saving state: %s", err)
 		return
@@ -913,7 +916,7 @@ func (di *DownloadInfo) downloadFragment(state *fragThreadState, dataChan chan<-
 		}
 
 		if state.ToFile {
-			err = os.WriteFile(fname, respData, 0644)
+			err = os.WriteFile(fname, respData, di.FileMode)
 			if err != nil {
 				LogDebug("%s: Failed to write fragment %d to file: %s", state.Name, state.SeqNum, err)
 				di.PrintStatus()

--- a/player_response.go
+++ b/player_response.go
@@ -352,7 +352,7 @@ func (di *DownloadInfo) GetPlayerResponse(videoHtml []byte) (*PlayerResponse, er
 	if len(prData) == 0 {
 		if debug && di.InProgress {
 			LogDebug("Could not find player response from video watch page. Writing html file to %s.html", di.VideoID)
-			os.WriteFile(fmt.Sprintf("%s.html", di.VideoID), videoHtml, 0644)
+			os.WriteFile(fmt.Sprintf("%s.html", di.VideoID), videoHtml, di.FileMode)
 		}
 		return nil, fmt.Errorf("unable to retrieve player response object from watch page")
 	}

--- a/util.go
+++ b/util.go
@@ -336,7 +336,7 @@ func DownloadData(url string) []byte {
 Download the given url to the given file name.
 Obviously meant to be used for thumbnail images.
 */
-func DownloadThumbnail(url, fname string) bool {
+func DownloadThumbnail(url, fname string, fileMode os.FileMode) bool {
 	resp, err := client.Get(url)
 	if err != nil {
 		LogWarn("Failed to download thumbnail: %v", err)
@@ -350,7 +350,7 @@ func DownloadThumbnail(url, fname string) bool {
 		return false
 	}
 
-	err = os.WriteFile(fname, data, 0644)
+	err = os.WriteFile(fname, data, fileMode)
 	if err != nil {
 		LogWarn("Failed to write thumbnail: %v", err)
 		os.Remove(fname)


### PR DESCRIPTION
Added a couple new cli options to control how files are created:

`--file-permissions` (or `-fp`) and `--directory-permissions` (or `-dp`) to specify which mode is used to create files and directories.
`--temp-directory` (or `-td`) to specify a directory for temporary files which solves #175 for me.