### PR TITLE
Update Android client version and add status code check

### DIFF
--- a/player_response.go
+++ b/player_response.go
@@ -309,6 +309,10 @@ func (di *DownloadInfo) DownloadAndroidPlayerResponse() (*PlayerResponse, error)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("returned non-200 status code %d", resp.StatusCode)
+	}
+
 	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/player_response.go
+++ b/player_response.go
@@ -24,7 +24,7 @@ const (
 	'context': {
 		'client': {
 			'clientName': 'ANDROID',
-			'clientVersion': '17.31.35',
+			'clientVersion': '19.09.37',
 			'hl': 'en'
 		}
 	},
@@ -275,7 +275,7 @@ func (di *DownloadInfo) DownloadAndroidPlayerResponse() (*PlayerResponse, error)
 	}
 
 	req.Header.Add("X-YouTube-Client-Name", "3")
-	req.Header.Add("X-YouTube-Client-Version", "17.31.35")
+	req.Header.Add("X-YouTube-Client-Version", "19.09.37")
 	req.Header.Add("Origin", "https://www.youtube.com")
 	req.Header.Add("content-type", "application/json")
 


### PR DESCRIPTION
Old client version stopped working again, updated based on latest yt-dlp version. Also added check if the response returns a non-200 status code so it gets debug logged when it fails instead of just silently skipping it.