### PR TITLE
Fix "/live/VideoID" Parsing

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -519,13 +519,8 @@ func (di *DownloadInfo) ParseInputUrl() error {
 			di.LiveURL = true
 			return nil
 		} else if strings.HasPrefix(lowerPath, "/live/") {
-			videoID := strings.TrimPrefix(lowerPath, "/live/")
-			videoID = strings.Trim(videoID, "/")
-
-			if len(videoID) > 0 {
-				di.VideoID = videoID
-				return nil
-			}
+			di.VideoID = strings.TrimPrefix(parsedUrl.EscapedPath(), "/live/")
+			return nil
 		}
 	} else if lowerHost == "youtu.be" {
 		di.VideoID = strings.TrimLeft(parsedUrl.EscapedPath(), "/")


### PR DESCRIPTION
Fixes all lowercase of parsed VideoID, so created files now display the correct YouTube video ID.
Attempted writing similarly to surrounding code, which most resembles `youtu.be` parsing but using TrimPrefix with "/live/". Checked output with a stream and it kept capitalizations.

Hoping this commit and pull request works out well; haven't really done this whole process before :p

Closes #182