### PR TITLE
Support YouTube links with `/shorts/` as part of the URL

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -522,6 +522,9 @@ func (di *DownloadInfo) ParseInputUrl() error {
 		} else if strings.HasPrefix(lowerPath, "/live/") {
 			di.VideoID = strings.TrimPrefix(parsedUrl.EscapedPath(), "/live/")
 			return nil
+		} else if strings.HasPrefix(lowerPath, "/shorts/") {
+			di.VideoID = strings.TrimPrefix(parsedUrl.EscapedPath(), "/shorts/")
+			return nil
 		}
 	} else if lowerHost == "youtu.be" {
 		di.VideoID = strings.TrimLeft(parsedUrl.EscapedPath(), "/")


### PR DESCRIPTION
Livestreams that are shorts seem to have a url like `https://www.youtube.com/shorts/<ID>`, which currently give an error if you use them with `ytarchive`. This PR just adds support for these URLs.

Tested by building and running with a shorts livestream that was scheduled to start soon. Prior to the change it would error out, after the change it accepts the URL.