### PR TITLE
Added --live-from-now and --live-from support

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ Options:
 
 	--live-from-now
 		Starts downloading from the current timestamp (now) instead of from the beginning of the stream.
+		(Does not affect resuming).
+		
+	--live-from [DURATION | NOW]
+		Starts downloading from a stream time in the past. Example: '1h10m' ago.
+		(Supports Days (d), Hours (h), Minutes (m) and Seconds (s)).
 
 Examples:
 	ytarchive -w

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
+	--live-from-now
+		Starts downloading from the current timestamp (now) instead of from the beginning of the stream.
+
 Examples:
 	ytarchive -w
 		Waits for a stream. Will prompt for a URL and quality.

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,7 @@ require (
 	golang.org/x/sys v0.3.0
 )
 
-require github.com/mattn/go-isatty v0.0.14 // indirect
+require (
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHR
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq4=
+github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed h1:p9UgmWI9wKpfYmgaV/IZKGdXc5qEK45tDwwwDyjS26I=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -298,6 +298,9 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
+	--live-from-now
+		Starts downloading from the current timestamp (now) instead of from the beginning of the stream.
+
 Examples:
 	%[1]s -w
 		Waits for a stream. Will prompt for a URL and quality.
@@ -415,6 +418,7 @@ var (
 	h264              bool
 	membersOnly       bool
 	disableSaveState  bool
+	liveFromNow       bool
 
 	cancelled = false
 )
@@ -483,6 +487,7 @@ func init() {
 	cliFlags.UintVar(&dirPerms, "directory-permissions", 0755, "Filesystem permissions for the created directories.")
 	cliFlags.UintVar(&filePerms, "fp", 0644, "Filesystem permissions for the created files.")
 	cliFlags.UintVar(&filePerms, "file-permissions", 0644, "Filesystem permissions for the created files.")
+	cliFlags.BoolVar(&liveFromNow, "live-from-now", false, "Starts downloading from the current timestamp instead of from the beginning (does not affect resuming).")
 
 	cliFlags.Func("video-url", "Googlevideo URL for the video stream.", func(s string) error {
 		var itag int
@@ -554,6 +559,7 @@ func run() int {
 	info.FileMode = os.FileMode(filePerms)
 	info.DirMode = os.FileMode(dirPerms)
 	info.DisableSaveState = disableSaveState
+	info.LiveFromNow = liveFromNow
 
 	if doWait {
 		info.Wait = ActionDo


### PR DESCRIPTION
Added support for '--live from now' to start downloading from the current time instead of the start of the stream.
Solves #149

Edit: Added support for '--live-from' to start downloading from a point in the past.
Solves #184


Edit: I didn't realize my new commits would add to the open Pull Request so I can split this into two if you want.