### PR TITLE
Add feature --live-from

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dannav/hhmmss"
 	"github.com/xhit/go-str2duration/v2"
 )
 
@@ -499,10 +500,15 @@ func (di *DownloadInfo) ParseLiveFromStrVal() error {
 	} else {
 		durationVal := strings.TrimPrefix(di.LiveFromVal, "-") // Removes negative symbol from start of duration string
 
+		// Try to parse the value as a duration string
 		duration, err := str2duration.ParseDuration(durationVal)
 		if err != nil {
-			errStr := fmt.Errorf("unable to parse duration string: %v", err)
-			return errors.New(errStr.Error())
+			// Try to parse the value as a HH:MM:SS string
+			duration, err = hhmmss.Parse(durationVal)
+			if err != nil {
+				errStr := fmt.Errorf("unable to parse value as either a duration or a time: %v", err)
+				return errors.New(errStr.Error())
+			}
 		}
 
 		secondsTotal := duration.Seconds()

--- a/Info.go
+++ b/Info.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/xhit/go-str2duration/v2"
 )
 
 const (
@@ -138,6 +141,7 @@ type MediaDLInfo struct {
 State for resumable downloading
 */
 type DownloadState struct {
+	StartFrag int
 	Fragments int
 	Size      int64
 	TempDir   string
@@ -168,6 +172,8 @@ type DownloadInfo struct {
 	MembersOnly      bool
 	InfoPrinted      bool
 	DisableSaveState bool
+	LiveFromVal      string
+	LiveFromSq       int
 
 	Thumbnail       string
 	VideoID         string
@@ -479,6 +485,69 @@ func (di *DownloadInfo) GetGvideoUrl(dataType string) {
 			LogGeneral("URL given does not appear to be appropriate for the data type needed.")
 		}
 	}
+}
+
+func (di *DownloadInfo) ParseLiveFromStrVal() error {
+	if di.LiveFromVal == "" {
+		return nil
+	}
+
+	if strings.ToLower(di.LiveFromVal) == "now" {
+		// --live-from now
+		//  Seek to current sequence number
+		di.LiveFromSq = di.LastSq
+	} else {
+		durationVal := strings.TrimPrefix(di.LiveFromVal, "-") // Removes negative symbol from start of duration string
+
+		duration, err := str2duration.ParseDuration(durationVal)
+		if err != nil {
+			errStr := fmt.Errorf("unable to parse duration string: %v", err)
+			return errors.New(errStr.Error())
+		}
+
+		secondsTotal := duration.Seconds()
+		fragDur := float64(di.TargetDuration)
+		secondsRoundedToFragLength := int(math.Ceil(secondsTotal/fragDur) * fragDur) // Rounds up to next frag interval time
+		noOfFragsToJump := secondsRoundedToFragLength / di.TargetDuration
+
+		if strings.HasPrefix(di.LiveFromVal, "-") {
+			// --live-from negative value
+			//  Seek to a sequence number in the past
+
+			// Invalid time specification (too short or too long)
+			if secondsTotal < 0 || secondsTotal > LiveMaximumSeekable {
+				errStr := fmt.Errorf("invalid duration specified %s. (maximum video seek time is %d days)", di.LiveFromVal, (LiveMaximumSeekable / 60 / 60 / 24))
+				return errors.New(errStr.Error())
+			}
+			// If the stream hasn't been live long enough for the specified duration
+			if noOfFragsToJump > di.LastSq {
+				streamLength := di.LastSq * di.TargetDuration
+				curStreamDuration := time.Duration(streamLength * 1e9)
+
+				errStr := fmt.Errorf("invalid duration specified. the stream has not been live for that long (live for %s)", curStreamDuration)
+				return errors.New(errStr.Error())
+			}
+
+			di.LiveFromSq = di.LastSq - noOfFragsToJump
+			LogInfo("--live-from: Jumping back %d seconds (-%d frags). Will start from sequence %d [current sq right now is %d]", secondsRoundedToFragLength, noOfFragsToJump, di.LiveFromSq, di.LastSq)
+		} else {
+			// --live-from positive value
+			//  Waits a specified timeframe and begins from a calculated future sequence number
+			if secondsTotal < 0 {
+				errStr := fmt.Errorf("invalid duration specified %s. (maximum video seek time is %d days)", di.LiveFromVal, (LiveMaximumSeekable / 60 / 60 / 24))
+				return errors.New(errStr.Error())
+			}
+
+			di.LiveFromSq = di.LastSq + noOfFragsToJump
+			LogGeneral("--live-from: Waiting %s (%d seconds) before starting...", di.LiveFromVal, secondsRoundedToFragLength)
+			LogInfo("--live-from: Waiting %s (%d seconds) before starting. Will start from sequence %d [current sq right now is %d]", di.LiveFromVal, secondsRoundedToFragLength, di.LiveFromSq, di.LastSq)
+
+			time.Sleep(time.Duration(secondsRoundedToFragLength+di.TargetDuration) * time.Second) // Waits for the specified length of time +1 frag interval (2 or 5 seconds etc).
+			info.GetVideoInfo()                                                                   // And now that the duration has elapsed, re-grab the video information (to update the latest sq).
+		}
+	}
+
+	return nil
 }
 
 func (di *DownloadInfo) ParseInputUrl() error {
@@ -1009,7 +1078,12 @@ func (di *DownloadInfo) DownloadStream(dataType, dataFile string, progressChan c
 		itag = di.Quality
 	}
 
+	var resumedState bool = false
 	if di.DLState[itag].Fragments > 0 {
+		if di.LiveFromSq != 0 {
+			LogWarn("%s: Option --live-from is being ignored as download is being resumed.", dataType)
+		}
+
 		f, err = os.OpenFile(dataFile, os.O_RDWR, 0666)
 		if err != nil {
 			LogWarn("%s: Failed to open %s to resume download: %s", dataType, dataFile, err)
@@ -1021,24 +1095,40 @@ func (di *DownloadInfo) DownloadStream(dataType, dataFile string, progressChan c
 				LogWarn("%s: Failed to seek %s to resume download: %s", dataType, dataFile, err)
 				LogWarn("%s: Will truncate and start from the beginning", dataType)
 				f, err = os.Create(dataFile)
+			} else {
+				resumedState = true
 			}
 		}
 	} else {
 		f, err = os.Create(dataFile)
 	}
 
-	if di.LastSq >= 0 {
-		curFrag = di.LastSq - (LiveMaximumSeekable / (di.TargetDuration))
+	if resumedState {
+		// Resumed state: Set the startFrag and curFrag values from the state file.
+		startFrag = di.DLState[itag].StartFrag
+		curFrag = startFrag + di.DLState[itag].Fragments
 		maxSeqs = di.LastSq
-	}
-
-	if curFrag < di.DLState[itag].Fragments {
-		curFrag = di.DLState[itag].Fragments
-	} else if curFrag > 0 {
-		LogWarn("%s: YT only retains the livestream 5 days past for seeking, starting from sequence %d (latest is %d)", dataType, curFrag, di.LastSq)
-		startFrag = curFrag
 	} else {
-		curFrag = 0
+		if di.LastSq >= 0 {
+			curFrag = di.LastSq - (LiveMaximumSeekable / (di.TargetDuration))
+			maxSeqs = di.LastSq
+		}
+
+		if di.LiveFromSq != 0 {
+			// --live-from: Set start sequence.
+			curFrag = di.LiveFromSq
+			startFrag = curFrag
+			LogWarn("[--live-from] %s: Starting from sequence %d (latest is %d)", dataType, startFrag, di.LastSq)
+		} else if curFrag > 0 {
+			// Stream that has been live for more than 5 days.
+			LogWarn("%s: YT only retains the livestream 5 days past for seeking, starting from sequence %d (latest is %d)", dataType, curFrag, di.LastSq)
+			startFrag = curFrag
+		} else {
+			// All other stream lengths.
+			curFrag = 0
+		}
+
+		di.DLState[itag].StartFrag = startFrag // Sets start frag in state file for resuming.
 	}
 	curSeq := curFrag
 

--- a/README.md
+++ b/README.md
@@ -268,15 +268,15 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
-	--live-from [DURATION] or [NOW]
-		Starts the download from the specified time duration string.
-		Can be a negative or positive duration or 'now'.
-		Supports Days (d), Hours (h), Minutes (m) and Seconds (s).
-		Examples: * '--live-from -1h10m' will seek backwards 1 hour and 10 minutes and then 
+	--live-from [DURATION | TIMESTR] or 'now'
+		Starts the download from the specified time in the future, the past or 'now'.
+		Use a negative value to skip back in time, positive value to wait to start.
+		Support time durations (e.g. 1d12h30m5s) or time strings (e.g. 12:30:05).
+		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes and then 
 		            start downloading from that time.
 		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
 		            start downloading.
-		          * '--live-from now' will start recording from the current stream timestamp.
+		          * '--live-from now' will start recording from the current stream time.
 
 Examples:
 	ytarchive -w

--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
+	--live-from [DURATION] or [NOW]
+		Starts the download from the specified time duration string.
+		Can be a negative or positive duration or 'now'.
+		Supports Days (d), Hours (h), Minutes (m) and Seconds (s).
+		Examples: * '--live-from -1h10m' will seek backwards 1 hour and 10 minutes and then 
+		            start downloading from that time.
+		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
+		            start downloading.
+		          * '--live-from now' will start recording from the current stream timestamp.
+
 Examples:
 	ytarchive -w
 		Waits for a stream. Will prompt for a URL and quality.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Options:
 	--ipv6
 		Make all connections using IPv6.
 
+	--info-only
+		Print stream information such as Video title, Selected quality
+		Stream start time and duration and then exits.
+
 	--add-metadata
 		Write some basic metadata information to the final file.
 
@@ -268,14 +272,17 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
-	--live-from [DURATION | TIMESTR] or 'now'
+	--live-from DURATION, TIMESTRING or NOW
 		Starts the download from the specified time in the future, the past or 'now'.
-		Use a negative value to skip back in time, positive value to wait to start.
-		Support time durations (e.g. 1d12h30m5s) or time strings (e.g. 12:30:05).
-		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes and then 
-		            start downloading from that time.
-		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
-		            start downloading.
+		Use a negative time value to skip back in time from now.
+		Use a positive time value to specify the timestamp in the stream to start 
+		capturing from (from the start of the stream).
+
+		Supports time durations (e.g. 1d8h30m5s) or time strings (e.g. 32:30:05).
+		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes from now
+					and then start downloading from that time.
+		          * '--live-from 1h10mm00s' will begin downloading from 1 hour 10 minutes 
+				    after the stream started.
 		          * '--live-from now' will start recording from the current stream time.
 
 Examples:

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.19
 require (
 	github.com/alessio/shellescape v1.4.1
 	github.com/mattn/go-colorable v0.1.11
+	github.com/xhit/go-str2duration/v2 v2.1.0
+	github.com/dannav/hhmmss v1.0.0
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/sys v0.3.0
-	github.com/xhit/go-str2duration/v2 v2.1.0
 )
 
 require github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mattn/go-colorable v0.1.11
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/sys v0.3.0
+	github.com/xhit/go-str2duration/v2 v2.1.0
 )
 
 require github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHR
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed h1:p9UgmWI9wKpfYmgaV/IZKGdXc5qEK45tDwwwDyjS26I=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/dannav/hhmmss v1.0.0 h1:/FjTOHXSEOuQIWwPs4abUS6s42ndAGhnVo17VbGnCMA=
+github.com/dannav/hhmmss v1.0.0/go.mod h1:LXyJMlU/lUpkUB4Mj5xQr3Ad1YQb7jBLajgzuKqpaV0=
 github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHRmPYs=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=

--- a/main.go
+++ b/main.go
@@ -298,15 +298,15 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
-	--live-from [DURATION] or [NOW]
-		Starts the download from the specified time duration string.
-		Can be a negative or positive duration or 'now'.
-		Supports Days (d), Hours (h), Minutes (m) and Seconds (s).
-		Examples: * '--live-from -1h10m' will seek backwards 1 hour and 10 minutes and then 
+	--live-from [DURATION | TIMESTR] or 'now'
+		Starts the download from the specified time in the future, the past or 'now'.
+		Use a negative value to skip back in time, positive value to wait to start.
+		Support time durations (e.g. 1d12h30m5s) or time strings (e.g. 12:30:05).
+		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes and then 
 		            start downloading from that time.
 		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
 		            start downloading.
-		          * '--live-from now' will start recording from the current stream timestamp.
+		          * '--live-from now' will start recording from the current stream time.
 
 Examples:
 	%[1]s -w

--- a/main.go
+++ b/main.go
@@ -298,14 +298,17 @@ Options:
 	--write-thumbnail
 		Write the thumbnail to a separate file.
 
-	--live-from [DURATION | TIMESTR] or 'now'
+	--live-from DURATION, TIMESTRING or NOW
 		Starts the download from the specified time in the future, the past or 'now'.
-		Use a negative value to skip back in time, positive value to wait to start.
-		Support time durations (e.g. 1d12h30m5s) or time strings (e.g. 12:30:05).
-		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes and then 
-		            start downloading from that time.
-		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
-		            start downloading.
+		Use a negative time value to skip back in time from now.
+		Use a positive time value to specify the timestamp in the stream to start 
+		capturing from (from the start of the stream).
+
+		Supports time durations (e.g. 1d8h30m5s) or time strings (e.g. 32:30:05).
+		Examples: * '--live-from -01:10:00' will seek backwards 1 hour and 10 minutes from now
+					and then start downloading from that time.
+		          * '--live-from 1h10mm00s' will begin downloading from 1 hour 10 minutes 
+				    after the stream started.
 		          * '--live-from now' will start recording from the current stream time.
 
 Examples:
@@ -676,7 +679,6 @@ func run() int {
 	if info.LiveFromVal != "" {
 		err = info.ParseLiveFromStrVal()
 		if err != nil {
-			LogError("--live-from: " + err.Error())
 			return 1
 		}
 	}

--- a/player_response.go
+++ b/player_response.go
@@ -486,6 +486,11 @@ func (di *DownloadInfo) GetPlayablePlayerResponse() (retrieved int, pr *PlayerRe
 				return PlayerResponseNotUsable, nil, nil
 			}
 
+			if di.LiveFromVal != "" && strings.HasPrefix(di.LiveFromVal, "-") {
+				LogError("Option --live-from with a negative duration is not valid for a scheduled stream.")
+				return PlayerResponseNotUsable, nil, nil
+			}
+
 			if di.Wait == ActionDoNot {
 				LogError("Stream has not started, and you have opted not to wait.")
 				return PlayerResponseNotUsable, nil, nil

--- a/util.go
+++ b/util.go
@@ -982,3 +982,54 @@ func GetFFmpegArgs(audioFile, videoFile, thumbnail, fileDir, fileName string, on
 		FileName: mergeFile,
 	}
 }
+
+func SecondsToDurationStr(seconds int) string {
+	days := seconds / (60 * 60 * 24)
+	seconds -= days * (60 * 60 * 24)
+
+	hours := seconds / (60 * 60)
+	seconds -= hours * (60 * 60)
+
+	minutes := seconds / 60
+	seconds -= minutes * 60
+
+	outputStr := ""
+	if days > 0 {
+		outputStr += fmt.Sprintf("%dd", days)
+	}
+	if hours > 0 {
+		outputStr += fmt.Sprintf("%dh", hours)
+	}
+	if minutes > 0 {
+		outputStr += fmt.Sprintf("%dm", minutes)
+	}
+	outputStr += fmt.Sprintf("%ds", seconds)
+
+	return outputStr
+}
+
+func SecondsToTimeStr(seconds int) string {
+	hours := seconds / (60 * 60)
+	seconds -= hours * (60 * 60)
+
+	minutes := seconds / 60
+	seconds -= minutes * 60
+
+	outputStr := ""
+	if hours > 0 {
+		outputStr += fmt.Sprintf("%0d:%02d:%02d", hours, minutes, seconds)
+	} else if minutes > 0 {
+		outputStr += fmt.Sprintf("%02d:%02d", minutes, seconds)
+	} else {
+		outputStr += fmt.Sprintf("%02d", seconds)
+	}
+
+	return outputStr
+}
+
+func SecondsToDurationAndTimeStr(seconds int) string {
+	durStr := SecondsToDurationStr(seconds)
+	timeStr := SecondsToTimeStr(seconds)
+
+	return durStr + " (" + timeStr + ")"
+}


### PR DESCRIPTION
Added support for the `--live-from` option.

This option allows users to specify that they want to start capturing from one of the following:
* Now
* A time in the past: e.g. 25 minutes ago
* A time in the future: e.g. Wait 30 minutes then start capturing.

---

Usage:
```
	--live-from [DURATION] or [NOW]
		Starts the download from the specified time duration string.
		Can be a negative or positive duration or 'now'.
		Supports Days (d), Hours (h), Minutes (m) and Seconds (s).
		Examples: * '--live-from -1h10m' will seek backwards 1 hour and 10 minutes and then 
		            start downloading from that time.
		          * '--live-from 45m30s' will wait 45 minutes and 30 seconds from now and then
		            start downloading.
		          * '--live-from now' will start recording from the current stream timestamp.
```

---

Features: 
* Does not break resuming of a partial download.
* If a scheduled stream, checks for a negative --live-from value and exits with an error.

--- 

Fixes #184 and #149