### PR TITLE
Option to use lookalike characters instead of underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Options:
 		Keep the final stream audio and video files after muxing them
 		instead of deleting them.
 
+	-l
+	--lookalike-chars
+		Use lookalikes for forbidden characters in the filename output format.
+		Emulates forbidden characters by using the same replacement characters as yt-dlp.
+		This will make the filenames look closer to the original titles.
+
 	--members-only
 		Only download members-only streams. Can only be used with channel URLs
 		such as /live, /streams, etc, and requires cookies.
@@ -334,7 +340,8 @@ FORMAT TEMPLATE OPTIONS
 	youtube-dl. See https://github.com/ytdl-org/youtube-dl#output-template
 
 	For file names, each template substitution is sanitized by replacing invalid file name
-	characters with underscore (_).
+	characters with an underscore (_). If '--lookalike-chars' is used, invalid file name
+	characters get replaced by the same lookalike characters that yt-dlp uses instead.
 
 	id (string): Video identifier
 	url (string): Video URL

--- a/util.go
+++ b/util.go
@@ -105,18 +105,6 @@ var (
 	client *http.Client
 )
 
-var fnameReplacer = strings.NewReplacer(
-	"<", "_",
-	">", "_",
-	":", "_",
-	`"`, "_",
-	"/", "_",
-	"\\", "_",
-	"|", "_",
-	"?", "_",
-	"*", "_",
-)
-
 /*
 Logging functions;
 ansi sgr 0=reset, 1=bold, while 3x sets the foreground color:
@@ -209,7 +197,33 @@ func InitializeHttpClient(proxyUrl *url.URL) {
 }
 
 // Remove any illegal filename chars
-func SterilizeFilename(s string) string {
+func SterilizeFilename(s string, lookalikeChars bool) string {
+	var fnameReplacer *strings.Replacer
+	if lookalikeChars {
+		fnameReplacer = strings.NewReplacer(
+			"<", "＜",
+			">", "＞",
+			":", "：",
+			`"`, "″",
+			"/", "⧸",
+			"\\", "⧹",
+			"|", "｜",
+			"?", "？",
+			"*", "＊",
+		)
+	} else {
+		fnameReplacer = strings.NewReplacer(
+			"<", "_",
+			">", "_",
+			":", "_",
+			`"`, "_",
+			"/", "_",
+			"\\", "_",
+			"|", "_",
+			"?", "_",
+			"*", "_",
+		)
+	}
 	return fnameReplacer.Replace(s)
 }
 
@@ -810,7 +824,7 @@ func FormatPythonMapString(format string, vals map[string]string) (string, error
 	}
 }
 
-func FormatFilename(format string, vals map[string]string) (string, error) {
+func FormatFilename(format string, vals map[string]string, lookalikeChars bool) (string, error) {
 	fnameVals := make(map[string]string)
 
 	for k, v := range vals {
@@ -818,7 +832,7 @@ func FormatFilename(format string, vals map[string]string) (string, error) {
 			fnameVals[k] = ""
 		}
 
-		fnameVals[k] = SterilizeFilename(v)
+		fnameVals[k] = SterilizeFilename(v, lookalikeChars)
 	}
 
 	fstr, err := FormatPythonMapString(format, fnameVals)


### PR DESCRIPTION
Added a flag `l` to use the same lookalike characters as yt-dlp. This allows the ytarchive output (such as livestream, description and thumbnail) and a possible accompanying yt-dlp output (such as live chat and metadata) to get saved in the same output directory when this flag is used. Useful especially when both programs are used in conjunction.