### PR TITLE
add more flexible date and time format

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -235,6 +235,13 @@ func NewFormatInfo() FormatInfo {
 		"channel":      "",
 		"upload_date":  "",
 		"start_date":   "",
+		"year":   "",
+		"month":   "",
+		"day":   "",
+		"start_time":   "",
+		"hours":   "",
+		"minutes":   "",
+		"seconds":   "",
 		"publish_date": "",
 		"description":  "",
 		"url":          "",
@@ -358,11 +365,23 @@ func (fi FormatInfo) SetInfo(player_response *PlayerResponse) {
 	pmfr := player_response.Microformat.PlayerMicroformatRenderer
 	vid := player_response.VideoDetails.VideoID
 	startDate := strings.ReplaceAll(pmfr.LiveBroadcastDetails.StartTimestamp, "-", "")
+	year, month, day, hours, minutes, seconds := "", "", "", "", "", ""
+	startTime := strings.ReplaceAll(pmfr.LiveBroadcastDetails.StartTimestamp, ":", "")
 	publishDate := strings.ReplaceAll(pmfr.PublishDate, "-", "")
 	url := fmt.Sprintf("https://www.youtube.com/watch?v=%s", vid)
 
 	if len(startDate) > 0 {
 		startDate = startDate[:8]
+		year = startDate[:4]
+		month = startDate[4:6]
+		day = startDate[6:8]
+	}
+
+	if len(startTime) > 0 {
+		startTime = startTime[11:17]
+		hours = startTime[:2]
+		minutes = startTime[2:4]
+		seconds = startTime[4:6]
 	}
 
 	fi["id"] = vid
@@ -372,6 +391,13 @@ func (fi FormatInfo) SetInfo(player_response *PlayerResponse) {
 	fi["channel"] = player_response.VideoDetails.Author
 	fi["upload_date"] = startDate
 	fi["start_date"] = startDate
+	fi["year"] = year
+	fi["month"] = month
+	fi["day"] = day
+	fi["start_time"] = startTime
+	fi["hours"] = hours
+	fi["minutes"] = minutes
+	fi["seconds"] = seconds
 	fi["publish_date"] = publishDate
 	fi["description"] = strings.TrimSpace(player_response.VideoDetails.ShortDescription)
 }

--- a/README.md
+++ b/README.md
@@ -364,6 +364,13 @@ FORMAT TEMPLATE OPTIONS
 	channel (string): Full name of the channel the livestream is on
 	upload_date (string: YYYYMMDD): Technically stream start date, UTC timezone - see note below
 	start_date (string: YYYYMMDD): Stream start date, UTC timezone
+	start_time (string: HHMMSS): Stream start time, UTC timezone
+	year (string): Year extracted from stream start date, UTC timezone
+	month (string): Month extracted from stream start date, UTC timezone
+	day (string): Day extracted from stream start date, UTC timezone
+	hours (string): Hours extracted from stream start date, UTC timezone
+	minutes (string): Minutes extracted from stream start date, UTC timezone
+	seconds (string): Seconds extracted from stream start date, UTC timezone
 	publish_date (string: YYYYMMDD): Stream publish date, UTC timezone
 	description (string): Video description [disallowed for file name format template]
 

--- a/main.go
+++ b/main.go
@@ -390,6 +390,13 @@ FORMAT TEMPLATE OPTIONS
 	channel (string): Full name of the channel the livestream is on
 	upload_date (string: YYYYMMDD): Technically stream start date, UTC timezone - see note below
 	start_date (string: YYYYMMDD): Stream start date, UTC timezone
+	start_time (string: HHMMSS): Stream start time, UTC timezone
+	year (string): Year extracted from stream start date, UTC timezone
+	month (string): Month extracted from stream start date, UTC timezone
+	day (string): Day extracted from stream start date, UTC timezone
+	hours (string): Hours extracted from stream start date, UTC timezone
+	minutes (string): Minutes extracted from stream start date, UTC timezone
+	seconds (string): Seconds extracted from stream start date, UTC timezone
 	publish_date (string: YYYYMMDD): Stream publish date, UTC timezone
 	description (string): Video description [disallowed for file name format template]
 


### PR DESCRIPTION
Add more string options to format time and date  : 

	start_time (string: HHMMSS): Stream start time, UTC timezone
	year (string): Year extracted from stream start date, UTC timezone
	month (string): Month extracted from stream start date, UTC timezone
	day (string): Day extracted from stream start date, UTC timezone
	hours (string): Hours extracted from stream start date, UTC timezone
	minutes (string): Minutes extracted from stream start date, UTC timezone
	seconds (string): Seconds extracted from stream start date, UTC timezone