### PR TITLE
Support YouTube links copied from mobile browser

### DIFF
--- a/Info.go
+++ b/Info.go
@@ -586,6 +586,7 @@ func (di *DownloadInfo) ParseInputUrl() error {
 
 	lowerHost := strings.ToLower(parsedUrl.Host)
 	lowerHost = strings.TrimPrefix(lowerHost, "www.")
+	lowerHost = strings.TrimPrefix(lowerHost, "m.")
 	lowerPath := strings.ToLower(parsedUrl.EscapedPath())
 	parsedQuery := parsedUrl.Query()
 


### PR DESCRIPTION
If you open YouTube on a mobile browser it'll be of the form `m.youtube.com/watch?`, which currently fails if you try to copy that link and pass it to `ytarchive`.

Tested by building a binary and testing a mobile link, which now is correctly parsed.